### PR TITLE
DEV: Refresh auto groups in tests to make them pass

### DIFF
--- a/spec/requests/discourse_needs_love/needs_love_controller_spec.rb
+++ b/spec/requests/discourse_needs_love/needs_love_controller_spec.rb
@@ -9,7 +9,7 @@ module DiscourseNeedsLove
     fab!(:post) { Fabricate(:post, topic: topic) }
 
     context "when signed in as an admin" do
-      fab!(:signed_in_admin) { Fabricate(:admin) }
+      fab!(:signed_in_admin) { Fabricate(:admin, refresh_auto_groups: true) }
 
       before do
         SiteSetting.needs_love_enabled = true


### PR DESCRIPTION
### What is this change?

We changed our access settings to be based on group membership rather than TL column. This requires some tests to refresh the group memberships to have the tests keep passing.