### PR TITLE
DEV: Update deprecated Font Awesome icon names

### DIFF
--- a/.discourse-compatibility
+++ b/.discourse-compatibility
@@ -1,2 +1,3 @@
+< 3.4.0.beta2-dev: 100fcf3c0f36dd425ac9607938c34d0fda41a166
 < 3.4.0.beta1-dev: 77f65f7ca1eb9aefc17f068a93526fcf1fde71f9
 < 3.3.0.beta1-dev: b2bef4c2cc8fcf1c8c955cf3bfaebbb88ce9ec82

--- a/plugin.rb
+++ b/plugin.rb
@@ -9,7 +9,7 @@
 
 enabled_site_setting :needs_love_enabled
 
-register_svg_icon "band-aid" if respond_to?(:register_svg_icon)
+register_svg_icon "bandage" if respond_to?(:register_svg_icon)
 
 require_relative "lib/discourse_needs_love/engine"
 


### PR DESCRIPTION
This PR updates deprecated Font Awesome icon names. For more detail, refer to the announcement at https://meta.discourse.org/t/-/325349.