### PR TITLE
DEV: fix acceptance tests

### DIFF
--- a/test/javascripts/acceptance/needs-love-disabled-test.js
+++ b/test/javascripts/acceptance/needs-love-disabled-test.js
@@ -1,16 +1,12 @@
 import { visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import { clearTopicFooterButtons } from "discourse/lib/register-topic-footer-button";
-import {
-  acceptance,
-  updateCurrentUser,
-} from "discourse/tests/helpers/qunit-helpers";
-import selectKit from "discourse/tests/helpers/select-kit-helper";
+import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 
 acceptance(
   "Discourse Needs Love | Needs Love disabled mobile",
   function (needs) {
-    needs.user();
+    needs.user({ can_needs_love: true });
     needs.mobileView();
     needs.settings({ needs_love_enabled: false });
     needs.hooks.beforeEach(function () {
@@ -18,13 +14,9 @@ acceptance(
     });
 
     test("Footer dropdown does not contain button", async function (assert) {
-      updateCurrentUser({ can_needs_love: true });
-      const menu = selectKit(".topic-footer-mobile-dropdown");
-
       await visit("/t/internationalization-localization/280");
-      await menu.expand();
-
-      assert.false(menu.rowByValue("needs-love").exists());
+      assert.dom(".topic-footer-mobile-dropdown-trigger").doesNotExist();
+      assert.dom("#topic-footer-button-needs-love").doesNotExist();
     });
   }
 );

--- a/test/javascripts/acceptance/needs-love-enabled-test.js
+++ b/test/javascripts/acceptance/needs-love-enabled-test.js
@@ -1,16 +1,12 @@
-import { visit } from "@ember/test-helpers";
+import { click, visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import { clearTopicFooterButtons } from "discourse/lib/register-topic-footer-button";
-import {
-  acceptance,
-  updateCurrentUser,
-} from "discourse/tests/helpers/qunit-helpers";
-import selectKit from "discourse/tests/helpers/select-kit-helper";
+import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 
 acceptance(
   "Discourse Needs Love | Needs Love enabled mobile",
   function (needs) {
-    needs.user();
+    needs.user({ can_needs_love: true });
     needs.mobileView();
     needs.settings({ needs_love_enabled: true });
     needs.hooks.beforeEach(function () {
@@ -18,13 +14,9 @@ acceptance(
     });
 
     test("Footer dropdown does contain button", async function (assert) {
-      updateCurrentUser({ can_needs_love: true });
-      const menu = selectKit(".topic-footer-mobile-dropdown");
-
       await visit("/t/internationalization-localization/280");
-      await menu.expand();
-
-      assert.true(menu.rowByValue("needs-love").exists());
+      await click(".topic-footer-mobile-dropdown-trigger");
+      assert.dom("#topic-footer-button-needs-love").exists();
     });
   }
 );


### PR DESCRIPTION
In https://github.com/discourse/discourse/commit/6ef0b5d508a298efa3682cc129e8144759426623 we changed the "dropdown" on mobile topic footer to be a `DMenu` instead of a `SelectKit` and in https://github.com/discourse/discourse/commit/1791abab25487c75fe2a3fb457f7ad9632ae9ca7 we made the "dropdown" clever when there was only one option available.

This fixes the acceptance tests to account for these changes.

Internal ref t/144698