### PR TITLE
FIX: Needs Love can tag topics the caller cannot see

### DIFF
--- a/app/controllers/discourse_needs_love/needs_love_controller.rb
+++ b/app/controllers/discourse_needs_love/needs_love_controller.rb
@@ -9,15 +9,14 @@ module DiscourseNeedsLove
     before_action :ensure_can_needs_love
 
     def needs_love
-      tag_name = SiteSetting.needs_love_tag
-
       topic = Topic.find_by(id: params[:topic_id])
-      tag = Tag.find_by(name: tag_name)
-      tag = Tag.create(name: tag_name) unless tag
+      guardian.ensure_can_see!(topic)
+
+      tag_name = SiteSetting.needs_love_tag
+      Tag.find_or_create_by(name: tag_name)
 
       old_tag_names = topic.tags.pluck(:name) || []
       tag_names = ([tag_name] + old_tag_names).uniq
-      tags = Tag.where(name: tag_names)
 
       PostRevisor.new(topic.first_post, topic).revise!(
         Discourse.system_user,

--- a/spec/requests/discourse_needs_love/needs_love_controller_spec.rb
+++ b/spec/requests/discourse_needs_love/needs_love_controller_spec.rb
@@ -48,6 +48,20 @@ module DiscourseNeedsLove
         expect(response.status).to eq(200)
         expect(topic.tags.exists?(name: "needs-love")).to eq(true)
       end
+
+      it "blocks tagging topics the user cannot see" do
+        group.add(signed_in_user)
+        private_group = Fabricate(:group)
+        private_category = Fabricate(:private_category, group: private_group)
+        private_topic = Fabricate(:topic, category: private_category)
+        Fabricate(:post, topic: private_topic)
+
+        put "/needs_love/needs_love/#{private_topic.id}.json"
+
+        expect(response.status).to eq(403)
+        expect(response.parsed_body["errors"]).to be_present
+        expect(private_topic.reload.tags.exists?(name: "needs-love")).to eq(false)
+      end
     end
   end
 end


### PR DESCRIPTION
## Summary

Atm any logged-in user who is in `needs_love_allowed_groups` could add the `needs-love` tag to any topic on the site by numeric ID — including PMs and topics in secure categories they have no access to.

This change adds `ensure_can_see!` so that's no longer possible

## Source

- Patch Triage: https://patch.discourse.org/patch-triage/1250
- Affected file: https://github.com/discourse/discourse-needs-love/blob/main/app/controllers/discourse_needs_love/needs_love_controller.rb

---

🤖 Auto-generated from the patch diff via Patch Triage. Review carefully before merging.

Co-authored-by: discourse-patch-triage <272280883+discourse-patch-triage[bot]@users.noreply.github.com>